### PR TITLE
Replace KID with OriginID/OID

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 
 ### In brief, this is how it works:
 
-- Alice runs her website on her device. She [exposes her local server with `ipns-link`](https://github.com/ipns-link/ipns-link/blob/main/tutorials/QuickStart.md) and gets an [IPNS-name or key](https://docs.ipfs.io/concepts/ipns/) that she can then distribute to her users/website-visitors.
-- Bob puts Alice's IPNS key in any [IPFS](https://ipfs.github.io/public-gateway-checker/) or [IPNS-Link](https://github.com/ipns-link/ipns-link-gateway) gateway in his browser. The gateway finds the [multiaddress](https://docs.libp2p.io/concepts/addressing/) of Alice's node from her IPNS record. It then establishes a persistent connection with her node and [proxies](https://github.com/ipfs/go-ipfs/blob/master/docs/experimental-features.md#p2p-http-proxy) for her server, delivering her website to Bob. Note that Bob can use any gateway, even a [self-hosted](https://github.com/ipns-link/ipns-link-gateway#self-hosting), local one. Alice's website, therefore, practically gets atleast as many URLs as there are public gateways: `http(s)://any.gateway.tld/ipns/AliceKey`.
+- Alice runs her website on her device. She [exposes her local server with `ipns-link`](https://github.com/ipns-link/ipns-link/blob/main/tutorials/QuickStart.md) and gets an [IPNS key](https://docs.ipfs.io/concepts/ipns/) (OriginID) that she can then distribute to her users/website-visitors.
+- Bob puts Alice's OriginID in any [IPFS](https://ipfs.github.io/public-gateway-checker/) or [IPNS-Link](https://github.com/ipns-link/ipns-link-gateway) gateway in his browser. The gateway finds the [multiaddress](https://docs.libp2p.io/concepts/addressing/) of Alice's node from her IPNS record. It then establishes a persistent connection with her node and [proxies](https://github.com/ipfs/go-ipfs/blob/master/docs/experimental-features.md#p2p-http-proxy) for her server, delivering her website to Bob. Note that Bob can use any gateway, even a [self-hosted](https://github.com/ipns-link/ipns-link-gateway#self-hosting), local one. Alice's website, therefore, practically gets atleast as many URLs as there are public gateways: `http(s)://any.gateway.tld/ipns/OriginID`.
 
 ### IPFS is used basically as a CDN:
 
 - Alice may pin the static contents of her website, such as images, media, css and javascripts, with an [IPFS cluster](https://cluster.ipfs.io/) or pinning-services such as [Pinata](https://www.pinata.cloud/).
-- Requests for those static contents from Bob's browser are served from IPFS. Only the requests for dynamic contents need ever reach Alice's origin-server.
+- Requests for those static contents from Bob's browser are served from IPFS. Only the requests for dynamic contents need ever reach Alice's Origin-server.
 
 ### IPFS also makes streaming efficient:
 
@@ -25,9 +25,9 @@
 
 ### Let's look at some more features:
 
-##### No need for domain names or DDNS. The IPNS-Key is enough
+##### No need for domain names or DDNS. The OriginID is enough
 
-- Alice can simply export her libp2p-key-pair into a file, copy the file to another machine and import the keypair there. She can then port her entire website to the new machine and expose its local server with `ipns-link`. Because she is using the same key-pair, her website can still be accessed using the same IPNS-key, although her website is now running on an entirely new machine with perhaps a new public IP address.
+- Alice can simply export her libp2p-keypair into a file, copy the file to another machine and import the keypair there. She can then port her entire website to the new machine and expose its local server with `ipns-link`. Because she is using the same key-pair, her website can still be accessed using the same OriginID, although her website is now running on an entirely new machine with perhaps a new public IP address.
 
 - Similarly, a dynamic public IP address doesn't cause any problem either.
 
@@ -41,7 +41,7 @@ If Alice has intermittent connections, Alice may configure [`ipns-link`](https:/
 
 ##### No need for SSL
 
-The p2p connection between the gateway and Alice's origin-server is [encrypted](https://docs.ipfs.io/concepts/privacy-and-encryption/#encryption). If Bob is using a local gateway on his machine to access Alice's website, then he is completely safe. Otherwise, he can simply use an https-enabled public gateway, such as https://www.ipns.live. Alice doesn't need to purchase and manage SSL certificates on her own anymore to serve securely.
+The p2p connection between the gateway and Alice's origin-server is [encrypted](https://docs.ipfs.io/concepts/privacy-and-encryption/#encryption). If Bob is using a local gateway on his machine to access Alice's website, then he is completely safe. Otherwise, he can simply use an https-enabled public gateway, such as https://gateway.ipnslink.com or https://ipns.live. Alice doesn't need to purchase and manage SSL certificates on her own anymore to serve securely.
 
 ##### Same origin policy
 
@@ -57,7 +57,7 @@ The gateways assign each website its own subdomain.
 
 True. [IPFS-gateway](https://docs.ipfs.io/concepts/ipfs-gateway/#overview)s are designed to serve static sites only, they can't serve as proxies. Hence, IPNS-Link needs its own gateway. [ipns.live](https://ipns.live) is an example running the [prototype implementation](https://github.com/ipns-link/ipns-link-gateway). **Anyone can host an IPNS-Link-gateway, as the code is free and open-source**.
 
-IPNS-Link-gateways and IPFS gateways, however, complement each other. Whenever Bob puts Alice's IPNS key into an IPFS gateway, it redirects Bob's browser to an IPNS-Link gateway that then connects Bob to Alice's site. On the other hand, an IPNS-Link-gateway redirects almost all requests for static contents to IPFS gateways, in order to offload itself.
+IPNS-Link-gateways and IPFS gateways, however, complement each other. Whenever Bob puts Alice's OriginID into an IPFS gateway, it redirects Bob's browser to an IPNS-Link gateway that then connects Bob to Alice's site. On the other hand, an IPNS-Link-gateway redirects almost all requests for static contents to IPFS gateways, in order to offload itself.
 
 ### Cool. But why care?
 
@@ -65,7 +65,7 @@ Let's look at the following use cases, then.
 
 ##### Censorship resistance
 
-A website (say, `example.com`) that is blocked in a country or region may be accessed easily using IPNS-Link. Because the site already has a domain name, its IPNS key can be conveniently distributed as a [DNSLink](https://docs.ipfs.io/concepts/dnslink/#dnslink). Gateways can automatically resolve DNSLinks. So, alternate URLs for that site would simply look like, `http(s)://gateway.tld/ipns/example.com`.
+A website (say, `example.com`) that is blocked in a country or region may be accessed easily using IPNS-Link. Because the site already has a domain name, its OriginID can be conveniently distributed as a [DNSLink](https://docs.ipfs.io/concepts/dnslink/#dnslink). Gateways can automatically resolve DNSLinks. So, alternate URLs for that site would simply look like, `http(s)://gateway.tld/ipns/example.com`.
 
 ##### Anonymity
 
@@ -97,9 +97,9 @@ A giant corporation can build its own [private IPFS network](https://github.com/
 
 ##### Shared-hosting providers
 
-Shared hosting providers need to assign a UUID and a subdomain to each accountholder. All that is built into IPNS-Link, the IPNS-key being the UUID and every IPNS-Link-gateway being a subdomain gateway. Therefore, shared-hosting providers can readily adopt IPNS-Link.
+Shared hosting providers need to assign a UUID and a subdomain to each accountholder. All that is built into IPNS-Link, the OriginID being the UUID and every IPNS-Link-gateway being a subdomain gateway. Therefore, shared-hosting providers can readily adopt IPNS-Link.
 
-If all hosting providers use IPNS-Link, this would have the following benefit. Each hosted website, *regardless of the hosting provider*, can be universally addressed by its unique IPNS-key and accessible using all IPNS-Link-gateways. This would make migrating to another hosting provider seamless, while also enabling multiple points of access.
+If all hosting providers use IPNS-Link, this would have the following benefit. Each hosted website, *regardless of the hosting provider*, can be universally addressed by its unique OriginID and accessible using all IPNS-Link-gateways. This would make migrating to another hosting provider seamless, while also enabling multiple points of access.
 
 ##### VPN
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ##### No need for domain names or DDNS. The OriginID is enough
 
-- Alice can simply export her libp2p-keypair into a file, copy the file to another machine and import the keypair there. She can then port her entire website to the new machine and expose its local server with `ipns-link`. Because she is using the same key-pair, her website can still be accessed using the same OriginID, although her website is now running on an entirely new machine with perhaps a new public IP address.
+- Alice can simply export her libp2p-keypair into a file, copy the file to another machine and import the keypair there. She can then port her entire website to the new machine and expose its local server with `ipns-link`. Because she is using the same keypair, her website can still be accessed using the same OriginID, although her website is now running on an entirely new machine with perhaps a new public IP address.
 
 - Similarly, a dynamic public IP address doesn't cause any problem either.
 

--- a/gateway.md
+++ b/gateway.md
@@ -1,6 +1,6 @@
 # IPNS-Link Gateway
 
-This document specifies how the gateway operates. For illustration, the base-domain of our gateway is assumed to be `https://gateway.tld` located at IP `1.2.3.4`. Also, just as `CID` is Content ID for IPFS, by `KID` we shall refer to the Key ID for IPNS. This also includes DNSLinks.
+This document specifies how the gateway operates. For illustration, the base-domain of our gateway is assumed to be `https://gateway.tld` located at IP `1.2.3.4`. `CID` refers to Content ID, `OriginID` refers to an Origin's key, but also can include DNSLinks.
 
 ### Types of incoming http-requests
 
@@ -14,46 +14,46 @@ GET or HEAD requests for resources local to the gateway server. For these, the g
 
 These requests are served as a subdomain-IPFS-Gateway, i.e. a [`303 See Other`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303) redirect is issued to https://CID.ipfs.gateway.tld/*. If a remote subdomain-IPFS-gateway is used for offloading, then that is where the redirect is targeted.
 
-##### https://gateway.tld/ipns/KID/* or https://www.gateway.tld/ipns/KID/*
+##### https://gateway.tld/ipns/OriginID/* or https://www.gateway.tld/ipns/OriginID/*
 
-The `KID` is first transformed into base36 libp2p-key. If `KID` is a DNSLink that points to an IPFS path, then gateway behaves as subdomain-IPFS-gateway as described above. Otherwise, a [`307 Temporary Redirect`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307) is issued to https://KID.ipns.gateway.tld/* where `KID` is in base36.
+The `OriginID` is first transformed into base36 libp2p-key. If `OriginID` is a DNSLink that points to an IPFS path, then gateway behaves as subdomain-IPFS-gateway as described above. Otherwise, a [`307 Temporary Redirect`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307) is issued to https://OriginID.ipns.gateway.tld/* where `OriginID` is in base36.
 
 ##### https://CID.ipfs.gateway.tld/*
 
 These requests are served as a subdomain-IPFS-Gateway. If a remote subdomain-IPFS-gateway, e.g. cf-ipfs.com, is used for offloading, then a 303 redirect is issued to https://CID.ipfs.cf-ipfs.com/*.
 
-##### https://KID.ipns.gateway.tld/*
+##### https://OriginID.ipns.gateway.tld/*
 
-`KID` in this context must be a base36 libp2p-key or a DNSLink. This is the main type of URL that is directly handled by the IPNS-Link gateway. Discussed in detail below.
+`OriginID` in this context must be a base36 libp2p-key or a DNSLink. This is the main type of URL that is directly handled by the IPNS-Link gateway. Discussed in detail below.
 
 ##### http://dnslink.tld/*
 
-This type of requests may be formed when an IPNS KID is DNSLink'd to say `dnslink.tld`and the DNSLink is CNAME'd to `gateway.tld`. In this case, gateway first obtains the `KID` by resolving the DNSLink. Then, the behavior is same as that of https://KID.ipns.gateway.tld/*, described below.
+This type of requests may be formed when an IPNS OriginID is DNSLink'd to say `dnslink.tld`and the DNSLink is CNAME'd to `gateway.tld`. In this case, gateway first obtains the `OriginID` by resolving the DNSLink. Then, the behavior is same as that of https://OriginID.ipns.gateway.tld/*, described below.
 
 ##### http://1.2.3.4/*
 
 307 redirect to https://gateway.tld/*
 
-### How to handle https://KID.ipns.gateway.tld/path or http://dnslink-of-KID.tld/path
+### How to handle https://OriginID.ipns.gateway.tld/path or http://dnslink-of-OriginID.tld/path
 
 Ordered according to precedence. In the [Bash implementation](https://github.com/ipns-link/ipns-link-gateway/blob/main/ipns-link-gateway), this is handled by the `forward` function.
 
 1. `path=/ipfs/CID/*` .AND. `Method==GET` : Same behavior as https://gateway.tld/ipfs/CID/* or https://www.gateway.tld/ipfs/CID/*, described above. **Exit**.
-2. `path=/ipfs/KID/*`: 307 redirect to https://gateway.tld/path. **Exit**.
-3. Transform `KID` to base36 libp2p key. This is not possible if KID is a DNSLink that points to an IPFS path. In that case, same behavior as https://CID.ipfs.gateway.tld/* and **Exit**. Otherwise, proceed with the base36 `KID`.
-4. Check if `KID` is blocked. In case it is issue [`451 Unavailable For Legal Reasons`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/451) and **Exit**.
-5. Access the JSON for `KID` from cache. If there is none in the cache or the cache is older than 24 hrs then:
-   1. Retrieve IPNS records for `KID` and read the Manifest therefrom. If timed out waiting for IPNS record, try to access it from a well-connected public gateway such as `ipfs.io` that has IPNS-pubsub enabled. If IPNS record is found but no Manifest, behave as a subdomain-IPFS-gateway and **Exit**. Otherwise:
+2. `path=/ipfs/OriginID/*`: 307 redirect to https://gateway.tld/path. **Exit**.
+3. Transform `OriginID` to base36 libp2p key. This is not possible if OriginID is a DNSLink that points to an IPFS path. In that case, same behavior as https://CID.ipfs.gateway.tld/* and **Exit**. Otherwise, proceed with the base36 `OriginID`.
+4. Check if `OriginID` is blocked. In case it is issue [`451 Unavailable For Legal Reasons`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/451) and **Exit**.
+5. Access the JSON for `OriginID` from cache. If there is none in the cache or the cache is older than 24 hrs then:
+   1. Retrieve IPNS records for `OriginID` and read the Manifest therefrom. If timed out waiting for IPNS record, try to access it from a well-connected public gateway such as `ipfs.io` that has IPNS-pubsub enabled. If IPNS record is found but no Manifest, behave as a subdomain-IPFS-gateway and **Exit**. Otherwise:
    2. Process Manifest as follows:
       1. If there is no IPNS-Link comment block in the Manifest, behave as a subdomain-IPFS-gateway and **Exit**. Otherwise:
-      2. Read the `secret` corresponding to `KID` as provided locally by the gateway maintainer.
-      3. Try to decipher the first line (ciphertext) of the comment block with a) the secret and b) the private-key. If successful, then cache the deciphered JSON against `KID`. Otherwise, pick a trusted-gateway randomly from the Manifest and 307 redirect to https://trusted-gateway.tld/ipns/`KID`/path and **Exit**. If no such gateway is provided in the Manifest, then [`401 Unauthorized`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401).
+      2. Read the `secret` corresponding to `OriginID` as provided locally by the gateway maintainer.
+      3. Try to decipher the first line (ciphertext) of the comment block with a) the secret and b) the private-key. If successful, then cache the deciphered JSON against `OriginID`. Otherwise, pick a trusted-gateway randomly from the Manifest and 307 redirect to https://trusted-gateway.tld/ipns/`OriginID`/path and **Exit**. If no such gateway is provided in the Manifest, then [`401 Unauthorized`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401).
 6. `Method==GET` .AND. `path=cache_path/*`: Serve the content of `/ipfs/cache_cid/*` and **Exit**.
 7. Read the Listener's multiaddress from the cached JSON and try to connect to it. 
    - On successful connection, put it in the peering subsystem so that the connection is maintained indefinitely and retried automatically on disconnect.
    - On failure, assume cache is stale and try retrieve the Manifest. If connection still fails after that then 307 redirect to the `on_fail` URL and **Exit**. In case `on_fail` is empty, issue a [`504 Gateway Timeout`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) and **Exit**.
-8. `Method==GET` .AND. `path=stream_path/*`: Serve the content of `/ipns/stream_kid/*` and **Exit**.
-9. Setup a p2p-forward to the Listener-node for `KID` with protocol `/x/ipns-link/KID`, if not setup already. Forward the web-request to Origin through that.
+8. `Method==GET` .AND. `path=stream_path/*`: Serve the content of `/ipns/stream_OriginID/*` and **Exit**.
+9. Setup a p2p-forward to the Listener-node for `OriginID` with protocol `/x/ipns-link/OriginID`, if not setup already. Forward the web-request to Origin through that.
 
 ### Pipeline
 

--- a/specs.md
+++ b/specs.md
@@ -11,10 +11,10 @@
 
 ### Participating nodes
 
-1.  ***Origin*** : The http-server that is to be exposed. Each Origin is assigned a unique Libp2p-keypair. A hash of the corresponding public key becomes the IPNS name that the Origin-server would ultimately be addressed by. **Note** : By ***IPNS-name*** or ***IPNS-key***, henceforth, we shall refer to this hash.
-2.  ***Listener*** : An IPFS node that listens for incoming connections over p2p-streams and forwards them to the Origin-server(s). The protocol name is **/x/ipns-link/`IPNS-key`**
-3.  ***Publisher*** : An IPFS node whose sole job is to periodically publish a ***Manifest*** for each Origin, containing the [multiaddress](https://docs.libp2p.io/concepts/addressing/)es of the Listener and metadata about the Origin. The Manifest is published using [IPNS pubsub](https://github.com/ipfs/go-ipfs/blob/master/docs/experimental-features.md#ipns-pubsub) under the IPNS-key of the corresponding Origin. **Note** : The same IPFS node may perform as both Listener and Publisher. However, separating the nodes helps reduce bandwidth consumption.
-4.  ***(Proxy) Gateway*** : An IPFS-aware http-proxy that, when given an IPNS-Key, connects the web-site visitors / end-users to the corresponding Origin via the Listener, after processing the Manifest published under that key. **Note** : This is distinct from an [IPFS-gateway](https://docs.ipfs.io/concepts/ipfs-gateway/), which can only serve static content from IPFS. The proxy Gateway can either be hosted locally by the end-user or publicly by a third-party.
+1.  ***Origin*** : The http-server that is to be exposed. Each Origin is assigned a unique Libp2p-keypair, the hash of the public key of this keypair is referred to as the **OriginID**.
+2.  ***Listener*** : An IPFS node that listens for incoming connections over p2p-streams and forwards them to the Origins. The protocol name is **/x/ipns-link/`OriginID`**
+3.  ***Publisher*** : An IPFS node whose sole job is to periodically publish a ***Manifest*** for each Origin, containing the [multiaddress](https://docs.libp2p.io/concepts/addressing/)es of the Listener and metadata about the Origin. The Manifest is published using [IPNS pubsub](https://github.com/ipfs/go-ipfs/blob/master/docs/experimental-features.md#ipns-pubsub) under the OriginID of the corresponding Origin. **Note** : The same IPFS node may perform as both Listener and Publisher. However, separating the nodes helps reduce bandwidth consumption.
+4.  ***(Proxy) Gateway*** : An IPFS-aware http-proxy that, when given an OriginID, connects the web-site visitors / end-users to the corresponding Origin via the Listener, after processing the Manifest published under that key. **Note** : This is distinct from an [IPFS-gateway](https://docs.ipfs.io/concepts/ipfs-gateway/), which can only serve static content from IPFS. The proxy Gateway can either be hosted locally by the end-user or publicly by a third-party.
 5.  ***Browser*** : Any user-agent, such as the browser, cURL, HTTPie, Postman etc. that can make http(s) requests to a Gateway on behalf of the end-user.
 
 
@@ -25,7 +25,7 @@
 
 - The Manifest contains all the information a Gateway needs to discover and connect to the Origin, through the Listener. In addition, it contains some instructions for the Gateway, set by the owner of the Origin. 
 - To ensure rapid dissemination, the Manifest is added to IPFS as **inline** and published using **IPNS pubsub**. Inlining encodes the entire Manifest inside the [CID](https://docs.ipfs.io/concepts/content-addressing/), so that no file needs to be imported separately after resolving the IPNS record. For efficient inlining, the Manifest needs to be as small in size as possible.
-- It is desirable that an IPFS-gateway be able to redirect the Browser to a proxy Gateway, when provided with the IPNS-key of an exposed Origin. However, an IPFS-gateway can only deliver the Manifest file to the Browser. The Manifest, therefore, needs to contain an html redirect to a proxy Gateway.
+- It is desirable that an IPFS-gateway be able to redirect the Browser to a proxy Gateway, when provided with the OriginID of an exposed Origin. However, an IPFS-gateway can only deliver the Manifest file to the Browser. The Manifest, therefore, needs to contain an html redirect to a proxy Gateway.
 - Because Gateways can always peek into the traffic between an end-user and the Origin, the Origin should have the liberty to choose only certain public Gateways as trusted. All the other Gateways would not be able to proxy for the Origin, but be able to redirect the Browser to one of the trusted Gateways.
 - In case the Origin cannot trust any public Gateway, there should be a way to ensure that access is allowed through users' private Gateways only. Such a Gateway may be hosted by the user on localhost or on a personal cloud or VPS. Because private gateways may not have a public address, the Origin cannot provide any trusted Gateway URL in this case. However, the Origin might instead specify a certain webpage, containing instructions for the users, that the public Gateways shall redirect to.
 
@@ -89,7 +89,7 @@ Meaning of the key-value pairs are discussed below. In the following, the `value
 
 `cache` : The Gateway is meant to serve `GET` requests for all paths prefixed with `<cache.path>` from the immutable (static) directory at `/ipfs/<cache.CID>`. All these requests are therefore served from IPFS and need not reach the Origin, thus reducing latency and offloading Origin.
 
-`on_fail` : On failure to connect (peer) with the Listener, the Gateway is to 307 redirect the browser to `<on_fail>`. The redirect destination might be a URL, an IPFS path `/ipfs/*` or an IPNS-key `/ipns/*`. If `null` or empty, the Gateway shall instead issue a [504](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) error code.
+`on_fail` : On failure to connect (peer) with the Listener, the Gateway is to 307 redirect the browser to `<on_fail>`. The redirect destination might be a URL, an IPFS path `/ipfs/*` or an OriginID `/ipns/*`. If `null` or empty, the Gateway shall instead issue a [504](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) error code.
 
 `stream` :  The Gateway is meant to serve `GET` requests for all paths prefixed with `<stream.path>` from the mutable (dynamic) directory at `/ipns/<stream.keyID>`. All these requests are therefore served from IPFS and need not reach the Origin, thus reducing latency and offloading Origin.
 

--- a/trustless.md
+++ b/trustless.md
@@ -20,25 +20,25 @@ Catching an MITM proxy from the client-side relies on the fact that the proxy ca
 
 ### E2E protocol and client-side monitor
 
-The default mode of IPNS-Link lets Gateway inspect the HTTP headers in order to serve content efficiently. The FQDN in this mode reads `kid.ipns.gateway.tld`, where `kid` denotes the IPNS key of Origin. To distinguish the E2E mode from this, the corresponding FQDN would be `kid.e2e.gateway.tld`. To terminate TLS, Origin needs a keypair and a valid TLS certificate. It might use its own libp2p keypair (`kid`), provided it is RSA 2048. Otherwise, it can create an RSA 2048 keypair and publish the fingerprint (SHA256) of the public key with its Manifest, in order to link it with its `kid`.
+The default mode of IPNS-Link lets Gateway inspect the HTTP headers in order to serve content efficiently. The FQDN in this mode reads `oid.ipns.gateway.tld`, where `oid` denotes the OriginID. To distinguish the E2E mode from this, the corresponding FQDN would be `oid.e2e.gateway.tld`. To terminate TLS, Origin needs a keypair and a valid TLS certificate. It might use its own libp2p keypair (`oid`), provided it is RSA 2048. Otherwise, it can create an RSA 2048 keypair and publish the fingerprint (SHA256) of the public key with its Manifest, in order to link it with its `oid`.
 
 The following describes how E2E is established.
 
-1. Gateway receives an HTTPS request with SNI `kid.e2e.gateway.tld`. It extracts the `kid` from the SNI.
-2. Gateway retrieves the Manifest for `kid`, decrypts it, peers with Origin and establishes TLS passthrough using the p2p protocol `/x/e2e/kid`. It also reads the TLS public key fingerprint of Origin, from the Manifest.
+1. Gateway receives an HTTPS request with SNI `oid.e2e.gateway.tld`. It extracts the `oid` from the SNI.
+2. Gateway retrieves the Manifest for `oid`, decrypts it, peers with Origin and establishes TLS passthrough using the p2p protocol `/x/e2e/oid`. It also reads the TLS public key fingerprint of Origin, from the Manifest.
 3. Origin creates a [CSR](https://en.wikipedia.org/wiki/Certificate_signing_request) corresponding to the SNI, using its RSA 2048 public key. Using ACME, it gets a valid TLS certificate from Let's Encrypt or ZeroSSL. To complete the TLS handshake, it responds to the Client Hello from Browser with the certificate, in its Server Hello.
 4. While passing the Server Hello through, Gateway extracts the public key and compares it with the fingerprint it read from the Manifest. On match, it lets the passthrough proceed. Otherwise, further connectivity is aborted, and the Origin is blacklisted locally. This prevents Origin from linking one public key in the Manifest and using another for TLS.
 
-The following describes how to monitor for possible MITMP at Gateway using client-side code. The client-side code may consist of a browser extension that reads URLs of the form `https://kid.e2e.gateway.tld/*` and screens `gateway.tld` for MITMP, or, it may consist of a static web-page (hosted on IPFS) where the end-user can manually enter `gateway.tld` and `kid` to screen for MITMP. The monitor might also be a command-line script or desktop app.
+The following describes how to monitor for possible MITMP at Gateway using client-side code. The client-side code may consist of a browser extension that reads URLs of the form `https://oid.e2e.gateway.tld/*` and screens `gateway.tld` for MITMP, or, it may consist of a static web-page (hosted on IPFS) where the end-user can manually enter `gateway.tld` and `oid` to screen for MITMP. The monitor might also be a command-line script or desktop app.
 
-1. Start a TLS handshake with `https://kid.e2e.gateway.tld` and extract the certificate from server hello. Therefrom extract the public key.
+1. Start a TLS handshake with `https://oid.e2e.gateway.tld` and extract the certificate from server hello. Therefrom extract the public key.
 2. Retrieve Origin's fingerprint from its Manifest using any IPFS-gateway.
 3. Compare the public key with the fingerprint. If they match, there is no MITMP. Otherwise warn the user and report the Gateway.
 
 **Note**: 
 
 - Client-side monitors screen for any on-path MITMP even at the level of ISP or DNS provider.
-- Once CAs start supporting ED25519, the libp2p-key of the Origin may be used for TLS. The `kid` itself would serve as the fingerprint then.
+- Once CAs start supporting ED25519, the libp2p-key of the Origin may be used for TLS. The `oid` itself would serve as the fingerprint then.
 - Client-side monitoring from different clients originate from different IP addresses - unpredictable to the Gateway. The suspect Gateway can no more dupe the monitor by passing TLS through instead of proxying.
 - The [TLS-ALPN-01](https://letsencrypt.org/docs/challenge-types/#tls-alpn-01) challenge for domain validation cannot always screen for MITMP. To avoid getting detected, the Gateway can simply passthrough the validation traffic as soon as it sees "[acme-tls/1](https://datatracker.ietf.org/doc/html/rfc8737#section-4)" as the Application-layer protocol.
 - Libp2p tunnels are themselves secured with [TLS 1.3](https://github.com/libp2p/specs/blob/master/tls/tls.md).
@@ -47,7 +47,7 @@ The following describes how to monitor for possible MITMP at Gateway using clien
 
 [DNSLink](https://dnslink.io/)s are most convenient when they are CNAMEd to a target Gateway. In conventional mode where TLS terminates at the Gateway, one cannot use https://dns.link unless the target Gateway can generate a TLS certificate for `dns.link` on the fly using [non-DNS-based challenges](https://letsencrypt.org/docs/challenge-types/). Because of the huge number of possible DNSLinks, which cannot be served with a catch-all wildcard certificate, most Gateways may not be able to provision per DNSLink certificates, because of latency and disk space concerns.
 
-Any given Origin, however, would be associated with only a small number of DNSLinks, and therefore, can provision certificates with ease. Whenever a TLSP Gateway receives HTTPS traffic with `dns.link` as the SNI, it can retrieve the `kid` by resolving the DNSLink and route the traffic accordingly.
+Any given Origin, however, would be associated with only a small number of DNSLinks, and therefore, can provision certificates with ease. Whenever a TLSP Gateway receives HTTPS traffic with `dns.link` as the SNI, it can retrieve the `oid` by resolving the DNSLink and route the traffic accordingly.
 
 Because TLS is terminated by the Origin, and *all* Gateways forward to the Origin, `https://dns.link` would work regardless of which Gateway `dns.link` is CNAMEd to. More conveniently, DNS records for `dns.link` may be configured to target multiple Gateways, in order to take advantage of [DNS-based load balancing](https://www.cloudflare.com/en-in/learning/performance/what-is-dns-load-balancing/).
 
@@ -56,9 +56,9 @@ Because TLS is terminated by the Origin, and *all* Gateways forward to the Origi
 Conventional DNSLinks, however, are not feasible for self-hosters who cannot afford a domain name. In view of this, IPNS-Link organization might provide an overarching domain, such as `umbrella.tld`, as follows:
 
 1. IPNS-Link organization is the sole controller of the domain. For DNS-based load balancing, it CNAMEs `*.umbrella.tld` to all registered public Gateways that it actively monitors. Whenever a Gateway fails the health check, the corresponding CNAME or A record is removed, until it is online again.
-2. Whenever a Gateway receives `https://kid.umbrella.tld`, it forwards the request to the Origin corresponding to `kid`, which generates a certificate for `kid.umbrella.tld` on the fly using a TLS-ALPN-01 challenge. Note that the same certificate can now be used for requests coming via different Gateways.
+2. Whenever a Gateway receives `https://oid.umbrella.tld`, it forwards the request to the Origin corresponding to `oid`, which generates a certificate for `oid.umbrella.tld` on the fly using a TLS-ALPN-01 challenge. Note that the same certificate can now be used for requests coming via different Gateways.
 
-Client-side MITM monitor might also benefit from this. Repeated monitoring attempts for `kid.umbrella.tld` screens all known paths to Origin.
+Client-side MITM monitor might also benefit from this. Repeated monitoring attempts for `oid.umbrella.tld` screens all known paths to Origin.
 
-Having an umbrella domain can enable DNS-based load-balancing for the default (non-E2E) mode too. To illustrate, if `umbrella.tld` is CNAMEd to all the registered Gateways, then URLs like `https://umbrella.tld/ipns/kid` may be TLS-terminated at the Gateway and redirected to `https://kid.ipns.gateway.tld`.
+Having an umbrella domain can enable DNS-based load-balancing for the default (non-E2E) mode too. To illustrate, if `umbrella.tld` is CNAMEd to all the registered Gateways, then URLs like `https://umbrella.tld/ipns/oid` may be TLS-terminated at the Gateway and redirected to `https://oid.ipns.gateway.tld`.
 


### PR DESCRIPTION
This pull request replaces all mentions of `KID`, IPNS-Key, and other terms with OriginID or `OID`.